### PR TITLE
Remove support for netcoreapp2.2, and add support for netcoreapp3.1 (v3.1.100-preview3)

### DIFF
--- a/HttpExceptions.sln
+++ b/HttpExceptions.sln
@@ -39,8 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opw.HttpExceptions.AspNetCo
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "02 Tests", "02 Tests", "{32D785A2-1383-4B5D-9186-A2F9E59239D7}"
 	ProjectSection(SolutionItems) = preProject
-		tests\test-netcoreapp2_2.ps1 = tests\test-netcoreapp2_2.ps1
 		tests\test-netcoreapp3_0.ps1 = tests\test-netcoreapp3_0.ps1
+		tests\test-netcoreapp3_1.ps1 = tests\test-netcoreapp3_1.ps1
 	EndProjectSection
 EndProject
 Global

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,12 +27,12 @@ steps:
 - task: gittools.gitversion.gitversion-task.GitVersion@4
   displayName: GitVersion
 
-# TODO: remove when build image has dotnet-core 3.0
-# https://dotnet.microsoft.com/download/dotnet-core/3.0
+# TODO: remove when build image has dotnet-core 3.1
+# https://dotnet.microsoft.com/download/dotnet-core/3.1
 - task: DotNetCoreInstaller@0
-  displayName: 'Install .Net Core 3.0'
+  displayName: 'Install .Net Core 3.1'
   inputs:
-    version: '3.0.100'
+    version: '3.1.100-preview3-014645'
 
 - task: DotNetCoreCLI@2
   displayName: Build

--- a/samples/Opw.HttpExceptions.AspNetCore.Sample/Opw.HttpExceptions.AspNetCore.Sample.csproj
+++ b/samples/Opw.HttpExceptions.AspNetCore.Sample/Opw.HttpExceptions.AspNetCore.Sample.csproj
@@ -1,16 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     </ItemGroup>
 

--- a/samples/Opw.HttpExceptions.AspNetCore.Sample/Startup.cs
+++ b/samples/Opw.HttpExceptions.AspNetCore.Sample/Startup.cs
@@ -7,9 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Opw.HttpExceptions.AspNetCore.Mappers;
 using Opw.HttpExceptions.AspNetCore.Sample.CustomErrors;
 using System;
-#if NETCOREAPP3_0
 using Microsoft.Extensions.Hosting;
-#endif
 
 namespace Opw.HttpExceptions.AspNetCore.Sample
 {
@@ -26,22 +24,11 @@ namespace Opw.HttpExceptions.AspNetCore.Sample
         public void ConfigureServices(IServiceCollection services)
         {
             IMvcBuilder mvcBuilder = null;
-#if NETCOREAPP2_2
-            mvcBuilder = services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-#endif
-#if NETCOREAPP3_0
             mvcBuilder = services.AddControllers().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
-#endif
             mvcBuilder.AddHttpExceptions(options =>
             {
-#if NETCOREAPP2_2
-                // This is the same as the default behavior; only include exception details in a development environment.
-                options.IncludeExceptionDetails = context => context.RequestServices.GetRequiredService<IHostingEnvironment>().IsDevelopment();
-#endif
-#if NETCOREAPP3_0
                 // This is the same as the default behavior; only include exception details in a development environment.
                 options.IncludeExceptionDetails = context => context.RequestServices.GetRequiredService<IWebHostEnvironment>().EnvironmentName == Environments.Development;
-#endif
                 // This is a simplified version of the default behavior; only map exceptions for 4xx and 5xx responses.
                 options.IsExceptionResponse = context => (context.Response.StatusCode >= 400 && context.Response.StatusCode < 600);
 
@@ -57,14 +44,8 @@ namespace Opw.HttpExceptions.AspNetCore.Sample
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
         }
 
-#if NETCOREAPP2_2
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
-#if NETCOREAPP3_0
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-#endif
         {
             // UseHttpExceptions is the first middleware component added to the pipeline. Therefore,
             // the UseHttpExceptions Middleware catches any exceptions that occur in later calls.
@@ -79,16 +60,10 @@ namespace Opw.HttpExceptions.AspNetCore.Sample
 
             app.UseHttpsRedirection();
 
-#if NETCOREAPP2_2
-            app.UseAuthentication();
-            app.UseMvc();
-#endif
-#if NETCOREAPP3_0
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#endif
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
@@ -5,9 +5,7 @@ using Opw.HttpExceptions.AspNetCore.Mappers;
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
-#if NETCOREAPP3_0
 using Microsoft.Extensions.Hosting;
-#endif
 
 namespace Opw.HttpExceptions.AspNetCore
 {
@@ -44,12 +42,7 @@ namespace Opw.HttpExceptions.AspNetCore
 
         private static bool IncludeExceptionDetails(HttpContext context)
         {
-#if NETSTANDARD2_0
-            return context.RequestServices.GetRequiredService<IHostingEnvironment>().IsDevelopment();
-#endif
-#if NETCOREAPP3_0
             return context.RequestServices.GetRequiredService<IWebHostEnvironment>().EnvironmentName == Environments.Development;
-#endif
         }
 
         private static bool IsExceptionResponse(HttpContext context)

--- a/src/Opw.HttpExceptions.AspNetCore/MvcBuilderExtensions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/MvcBuilderExtensions.cs
@@ -55,9 +55,6 @@ namespace Opw.HttpExceptions.AspNetCore
         {
             options.SuppressMapClientErrors = true;
             options.SuppressModelStateInvalidFilter = false;
-#if NETSTANDARD2_0
-            options.SuppressUseValidationProblemDetailsForInvalidModelStateResponses = true;
-#endif
             options.InvalidModelStateResponseFactory = (actionContext) => HandleInvalidModelStateResponse(actionContext);
         }
 

--- a/src/Opw.HttpExceptions.AspNetCore/Opw.HttpExceptions.AspNetCore.csproj
+++ b/src/Opw.HttpExceptions.AspNetCore/Opw.HttpExceptions.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Opw.HttpExceptions.AspNetCore</RootNamespace>
     <Description>Middleware and extensions for returning exceptions over HTTP, e.g. as ASP.NET Core Problem Details (RFC7807).</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,11 +9,7 @@
     <PackageTags>aspnetcore http exceptions RFC7807 problemdetails problem details</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
     <!--Ignore warning NETSDK1080; Microsoft.AspNetCore.App package reference is needed otherwise the code will not compile. -->
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/DefaultApiBehaviorStartup.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/DefaultApiBehaviorStartup.cs
@@ -10,12 +10,7 @@ namespace Opw.HttpExceptions.AspNetCore
         public void ConfigureServices(IServiceCollection services)
         {
             IMvcBuilder mvcBuilder = null;
-#if NETCOREAPP2_2
-            mvcBuilder = services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-#endif
-#if NETCOREAPP3_0
             mvcBuilder = services.AddControllers().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
-#endif
             mvcBuilder.AddHttpExceptions();
 
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();
@@ -24,16 +19,10 @@ namespace Opw.HttpExceptions.AspNetCore
         public void Configure(IApplicationBuilder app)
         {
             app.UseHttpExceptions();
-#if NETCOREAPP2_2
-            app.UseAuthentication();
-            app.UseMvc();
-#endif
-#if NETCOREAPP3_0
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#endif
         }
     }
 }

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>Opw.HttpExceptions.AspNetCore</RootNamespace>
     </PropertyGroup>
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
           <PrivateAssets>all</PrivateAssets>
@@ -20,13 +20,7 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     </ItemGroup>

--- a/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>Opw.HttpExceptions.AspNetCore.Sample</RootNamespace>
     </PropertyGroup>
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="5.9.0" />        
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
           <PrivateAssets>all</PrivateAssets>
@@ -20,12 +20,7 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     </ItemGroup>
 

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpResponseMessageExtensions.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpResponseMessageExtensions.cs
@@ -12,15 +12,10 @@ namespace Opw.HttpExceptions.AspNetCore
             response.StatusCode.Should().Be(statusCode);
             response.Content.Headers.ContentType.MediaType.Should().Be("application/problem+json");
 
-#if NETCOREAPP2_2
-            var problemDetails = response.Content.ReadAsAsync<ProblemDetails>().Result;
-#endif
-#if NETCOREAPP3_0
             var str = response.Content.ReadAsStringAsync().Result;
             var converter = new ProblemDetailsJsonConverter();
             var reader = new System.Text.Json.Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(str));
             var problemDetails = converter.Read(ref reader, typeof(ProblemDetails), new JsonOptions().JsonSerializerOptions);
-#endif
 
             problemDetails.Should().NotBeNull();
             problemDetails.Status.Should().Be((int)statusCode);

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>Opw.HttpExceptions.AspNetCore</RootNamespace>
     </PropertyGroup>
@@ -12,7 +12,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="Moq" Version="4.13.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
@@ -21,7 +21,7 @@
         </PackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     </ItemGroup>
 

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/ProblemDetailsExtensions.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/ProblemDetailsExtensions.cs
@@ -47,7 +47,6 @@ namespace Opw.HttpExceptions.AspNetCore
                 exception = serializableException;
             if (value is Newtonsoft.Json.Linq.JToken jTokens)
                 exception = jTokens.ToObject<SerializableException>();
-#if NETCOREAPP3_0
             if (value is System.Text.Json.JsonElement jsonElement)
             {
                 var str = jsonElement.GetRawText();
@@ -63,7 +62,6 @@ namespace Opw.HttpExceptions.AspNetCore
 
                 exception = Newtonsoft.Json.JsonConvert.DeserializeObject<SerializableException>(str, settings);
             }
-#endif
 
             return exception != null;
         }

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/ProblemDetailsJsonConverter.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/ProblemDetailsJsonConverter.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP3_0
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Text.Json;
@@ -130,4 +129,3 @@ namespace Opw.HttpExceptions.AspNetCore
         }
     }
 }
-#endif

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
@@ -11,12 +11,7 @@ namespace Opw.HttpExceptions.AspNetCore
     {
         public static void SetHostEnvironmentName(IWebHost webHost, string environmentName)
         {
-#if NETCOREAPP2_2
-            webHost.Services.GetRequiredService<IHostingEnvironment>().EnvironmentName = environmentName;
-#endif
-#if NETCOREAPP3_0
             webHost.Services.GetRequiredService<IWebHostEnvironment>().EnvironmentName = environmentName;
-#endif
         }
 
         public static Mock<IOptions<HttpExceptionsOptions>> CreateHttpExceptionsOptionsMock(bool includeExceptionDetails)

--- a/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
+++ b/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Opw.HttpExceptions</RootNamespace>
   </PropertyGroup>
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/test-netcoreapp2_2.ps1
+++ b/tests/test-netcoreapp2_2.ps1
@@ -1,3 +1,0 @@
-dotnet build ../HttpExceptions.sln --configuration Release
-dotnet test ../HttpExceptions.sln --configuration Release --framework netcoreapp2.2 --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[Opw.*]*" /p:Exclude="[*.Tests]*%2c[*.*Tests]*"
-PAUSE

--- a/tests/test-netcoreapp3_1.ps1
+++ b/tests/test-netcoreapp3_1.ps1
@@ -1,0 +1,3 @@
+dotnet build ../HttpExceptions.sln --configuration Release
+dotnet test ../HttpExceptions.sln --configuration Release --framework netcoreapp3.1 --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[Opw.*]*" /p:Exclude="[*.Tests]*%2c[*.*Tests]*"
+PAUSE


### PR DESCRIPTION
Remove support for netcoreapp2.2, and add support for netcoreapp3.1 (v3.1.100-preview3)

closes #35 Stop support for .NET Core 2.2.x when EOL (2019-12-23) 