### PR TITLE
Make logging errors configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ mvcBuilder.AddHttpExceptions(options =>
 });
 ```
 
+#### Should log exceptions (ILogger)
+Should an exception be logged by the HttpExceptions middleware or not, default behavior is to log all exceptions (all status codes).
+
+``` csharp
+mvcBuilder.AddHttpExceptions(options =>
+{
+    // Only log the when it has a status code of 500 or higher, or when it not is a HttpException.
+    options.ShouldLogException = exception => {
+        if ((exception is HttpExceptionBase httpException && (int)httpException.StatusCode >= 500) || !(exception is HttpExceptionBase))
+            return true;
+        return false;
+    };
+});
+```
+
 #### Custom ExceptionMappers
 Set the ExceptionMapper collection that will be used during mapping. You can override and/or add ExceptionMappers for specific
 exception types. The ExceptionMappers are called in order so make sure you add them in the right order.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,10 @@ steps:
 
 # TODO: remove when build image has dotnet-core 3.1
 # https://dotnet.microsoft.com/download/dotnet-core/3.1
-- task: DotNetCoreInstaller@0
-  displayName: 'Install .Net Core 3.1'
+- task: UseDotNet@2
+  displayName: Install .Net Core 3.1
   inputs:
+    packageType: 'sdk'
     version: '3.1.100'
 
 - task: DotNetCoreCLI@2

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -22,7 +22,7 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, bool> IsExceptionResponse { get; set; }
 
         /// <summary>
-        /// Should the exception be logged by the HttpExceptions middleware or not, default behavior is to log all exceptions (all status codes).
+        /// Should an exception be logged by the HttpExceptions middleware or not, default behavior is to log all exceptions (all status codes).
         /// </summary>
         public Func<Exception, bool> ShouldLogException { get; set; }
 

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -22,6 +22,11 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, bool> IsExceptionResponse { get; set; }
 
         /// <summary>
+        /// Should the exception be logged by the HttpExceptions middleware or not, default behavior is to log all exceptions (all status codes).
+        /// </summary>
+        public Func<Exception, bool> ShouldLogException { get; set; }
+
+        /// <summary>
         /// Register of the ExceptionMappers that will be used during mapping.
         /// </summary>
         public IDictionary<Type, ExceptionMapperDescriptor> ExceptionMapperDescriptors { get; set; } = new Dictionary<Type, ExceptionMapperDescriptor>();

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
@@ -36,6 +36,9 @@ namespace Opw.HttpExceptions.AspNetCore
             if (options.IsExceptionResponse == null)
                 options.IsExceptionResponse = IsExceptionResponse;
 
+            if (options.ShouldLogException == null)
+                options.ShouldLogException = ShouldLogException;
+
             ConfigureExceptionMappers(options);
             ConfigureHttpResponseMappers(options);
         }
@@ -57,6 +60,11 @@ namespace Opw.HttpExceptions.AspNetCore
                 return true;
 
             return false;
+        }
+
+        private static bool ShouldLogException(Exception ex)
+        {
+            return true;
         }
 
         private void ConfigureExceptionMappers(HttpExceptionsOptions options)

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/DefaultApiBehaviorStartup.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/DefaultApiBehaviorStartup.cs
@@ -9,8 +9,7 @@ namespace Opw.HttpExceptions.AspNetCore
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            IMvcBuilder mvcBuilder = null;
-            mvcBuilder = services.AddControllers().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+            var mvcBuilder = services.AddControllers().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
             mvcBuilder.AddHttpExceptions();
 
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer();

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />
+        <PackageReference Include="FluentAssertions" Version="5.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />        
+        <PackageReference Include="FluentAssertions" Version="5.10.0" />        
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpExceptionsMiddlewareTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpExceptionsMiddlewareTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using System;
 using System.Net;
@@ -16,15 +17,17 @@ namespace Opw.HttpExceptions.AspNetCore
     {
         private readonly HttpExceptionsMiddleware _middleware;
         private readonly Mock<RequestDelegate> _nextMock;
+        private readonly Mock<IOptions<HttpExceptionsOptions>> _optionsMock;
+        private readonly Mock<ILogger<HttpExceptionsMiddleware>> _loggerMock;
         private readonly Mock<IActionResultExecutor<ObjectResult>> _actionResultExecutorMock;
 
         public HttpExceptionsMiddlewareTests()
         {
             _nextMock = new Mock<RequestDelegate>();
-            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(true);
+            _optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(true);
             _actionResultExecutorMock = new Mock<IActionResultExecutor<ObjectResult>>();
-            var loggerMock = new Mock<ILogger<HttpExceptionsMiddleware>>();
-            _middleware = new HttpExceptionsMiddleware(_nextMock.Object, optionsMock.Object, loggerMock.Object);
+            _loggerMock = new Mock<ILogger<HttpExceptionsMiddleware>>();
+            _middleware = new HttpExceptionsMiddleware(_nextMock.Object, _optionsMock.Object, _loggerMock.Object);
         }
 
         [Fact]
@@ -77,6 +80,70 @@ namespace Opw.HttpExceptions.AspNetCore
             result.StatusCode.Should().Be((int)HttpStatusCode.Unauthorized);
             result.Value.ShouldNotBeNull(HttpStatusCode.Unauthorized);
             result.Value.Title.Should().Be("Unauthorized");
+        }
+
+        [Fact]
+        public async Task Invoke_Should_LogError_WithDefaultShouldLogExceptionConstraints()
+        {
+            //var options = _optionsMock.Object.Value;
+            //options.ShouldLogException = (exception) => {
+            //    return true;
+            //};
+            //_optionsMock.Setup(o => o.Value).Returns(options);
+
+            _nextMock.Setup(n => n.Invoke(It.IsAny<HttpContext>())).Throws(new ApplicationException());
+            ProblemDetailsResult result = null;
+            _actionResultExecutorMock.Setup(e => e.ExecuteAsync(It.IsAny<ActionContext>(), It.IsAny<ObjectResult>()))
+                .Callback<ActionContext, ObjectResult>((actionContext, actionResult) => result = (ProblemDetailsResult)actionResult)
+                .Returns(Task.CompletedTask);
+
+            var services = new ServiceCollection();
+            services.AddTransient((_) => _actionResultExecutorMock.Object);
+            var context = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            };
+
+            await _middleware.Invoke(context);
+
+            _loggerMock.Verify(l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_Should_NotLogError_WithCustomShouldLogExceptionConstraints()
+        {
+            var options = _optionsMock.Object.Value;
+            options.ShouldLogException = (_) => false;
+            _optionsMock.Setup(o => o.Value).Returns(options);
+
+            _nextMock.Setup(n => n.Invoke(It.IsAny<HttpContext>())).Throws(new ApplicationException());
+            ProblemDetailsResult result = null;
+            _actionResultExecutorMock.Setup(e => e.ExecuteAsync(It.IsAny<ActionContext>(), It.IsAny<ObjectResult>()))
+                .Callback<ActionContext, ObjectResult>((actionContext, actionResult) => result = (ProblemDetailsResult)actionResult)
+                .Returns(Task.CompletedTask);
+
+            var services = new ServiceCollection();
+            services.AddTransient((_) => _actionResultExecutorMock.Object);
+            var context = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider()
+            };
+
+            await _middleware.Invoke(context);
+
+            _loggerMock.Verify(l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Never);
         }
     }
 }

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpExceptionsOptionsTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/HttpExceptionsOptionsTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System;
+using Xunit;
+using Moq;
+using Opw.HttpExceptions.AspNetCore.Mappers;
+using System.Net;
+
+namespace Opw.HttpExceptions.AspNetCore
+{
+    public class HttpExceptionsOptionsTests
+    {
+        private readonly Mock<IOptions<HttpExceptionsOptions>> _httpExceptionsOptionsMock;
+        private readonly DefaultHttpContext _internalServerErrorHttpContext;
+
+        public HttpExceptionsOptionsTests()
+        {
+            _httpExceptionsOptionsMock = TestHelper.CreateHttpExceptionsOptionsMock(true);
+
+            _internalServerErrorHttpContext = new DefaultHttpContext();
+            _internalServerErrorHttpContext.Request.Path = "/api/test/internal-server-error";
+            _internalServerErrorHttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        }
+
+        [Fact]
+        public void TryMap_Should_ReturnTrue_WhenMappingConfiguredException()
+        {
+            var options = new HttpExceptionsOptions();
+            options.ExceptionMappers.Add(new ProblemDetailsExceptionMapper<HttpException>(_httpExceptionsOptionsMock.Object));
+
+            var result = options.TryMap(new HttpException(), new DefaultHttpContext(), out _);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TryMap_Should_ReturnFalse_WhenMappingNotConfiguredException()
+        {
+            var options = new HttpExceptionsOptions();
+            options.ExceptionMappers.Add(new ProblemDetailsExceptionMapper<HttpException>(_httpExceptionsOptionsMock.Object));
+
+            var result = options.TryMap(new ArgumentException(), new DefaultHttpContext(), out _);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryMap_Should_ReturnTrue_WhenMappingConfiguredHttpResponse()
+        {
+            var options = new HttpExceptionsOptions();
+            options.HttpResponseMappers.Add(new ProblemDetailsHttpResponseMapper(_httpExceptionsOptionsMock.Object) { Status = 500 });
+
+            var result = options.TryMap(_internalServerErrorHttpContext.Response, out _);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TryMap_Should_ReturnFalse_WhenMappingNotConfiguredHttpResponse()
+        {
+            var options = new HttpExceptionsOptions();
+            options.HttpResponseMappers.Add(new ProblemDetailsHttpResponseMapper(_httpExceptionsOptionsMock.Object) { Status = 148 });
+
+            var result = options.TryMap(_internalServerErrorHttpContext.Response, out _);
+
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+        <PackageReference Include="coverlet.msbuild" Version="2.8.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />
+        <PackageReference Include="FluentAssertions" Version="5.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-        <PackageReference Include="Moq" Version="4.13.0" />
+        <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
           <PrivateAssets>all</PrivateAssets>

--- a/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
+++ b/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
+++ b/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
Added `ShouldLogException` configuration option to make logging of errors configurable in the options.

closes #44