### PR TITLE
Using RFC as ProblemDetails type

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ mvcBuilder.AddHttpExceptions(options =>
 ```
 
 #### Use a help link for ProblemDetails type property
-When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
-And when you want to set a default link for your help pages, you can set `DefaultHelpLinkForProblemDetailsType`.
+When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the `Exception.HelpLink` or the HTTP status code information link to map the `ProblemDetails.Type` property.
+And when you want to set a default link for your help pages, you can set `DefaultHelpLink`.
 
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ mvcBuilder.AddHttpExceptions(options =>
 });
 ```
 
+#### Use a help link for ProblemDetails type property
+When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
+And when you want to set a default link for your help pages, you can set `DefaultHelpLinkForProblemDetailsType`.
+
+``` csharp
+mvcBuilder.AddHttpExceptions(options =>
+{
+    options.UseHelpLinkAsProblemDetailsType = true;
+    options.DefaultHelpLink = new Uri("http://www.example.com/help-page");
+});
+```
+
 #### Custom ExceptionMappers
 Set the ExceptionMapper collection that will be used during mapping. You can override and/or add ExceptionMappers for specific
 exception types. The ExceptionMappers are called in order so make sure you add them in the right order.

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -27,6 +27,17 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<Exception, bool> ShouldLogException { get; set; }
 
         /// <summary>
+        /// Use the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
+        /// </summary>
+        public bool UseHelpLinkAsProblemDetailsType { get; set; }
+
+        /// <summary>
+        /// If set, UseHelpLinkAsProblemDetailsType is TRUE and Exception.HelpLink or the HTTP status code information
+        /// link are empty this link will be used to map the ProblemDetails.Type property.
+        /// </summary>
+        public Uri DefaultHelpLink { get; set; }
+
+        /// <summary>
         /// Register of the ExceptionMappers that will be used during mapping.
         /// </summary>
         public IDictionary<Type, ExceptionMapperDescriptor> ExceptionMapperDescriptors { get; set; } = new Dictionary<Type, ExceptionMapperDescriptor>();

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -154,10 +154,11 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <param name="context">The HTTP context.</param>
-        /// <returns>Returns the URI with the Exception type name ("error:[Type:slug]").</returns>
+        /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            return new Uri($"error:{MapTitle(exception, context).ToSlug()}").ToString();
+            var url = exception.HelpLink ?? $"error:{MapTitle(exception, context).ToSlug()}";
+            return new Uri(url).ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,19 +157,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            Uri link = null;
-            if (!string.IsNullOrWhiteSpace(exception.HelpLink))
+            Uri uri = null;
+            if (Options.Value.UseHelpLinkAsProblemDetailsType)
             {
-                try
+                if (!string.IsNullOrWhiteSpace(exception.HelpLink))
                 {
-                    link = new Uri(exception.HelpLink);
+                    try
+                    {
+                        uri = new Uri(exception.HelpLink);
+                    }
+                    catch { }
                 }
-                catch { }
+
+                uri ??= Options.Value.DefaultHelpLink;
             }
 
-            link ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+            uri ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
 
-            return link.ToString();
+            return uri.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,8 +157,19 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            var url = exception.HelpLink ?? $"error:{MapTitle(exception, context).ToSlug()}";
-            return new Uri(url).ToString();
+            Uri link = null;
+            if (!string.IsNullOrWhiteSpace(exception.HelpLink))
+            {
+                try
+                {
+                    link = new Uri(exception.HelpLink);
+                }
+                catch { }
+            }
+
+            link ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+
+            return link.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -141,16 +141,22 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            string url = null;
-            try
+            Uri uri = null;
+            if (Options.Value.UseHelpLinkAsProblemDetailsType)
             {
-                ((HttpStatusCode)response.StatusCode).TryGetLink(out url);
+                try
+                {
+                    ((HttpStatusCode)response.StatusCode).TryGetLink(out var url);
+                    uri = new Uri(url);
+                }
+                catch { }
+
+                uri ??= Options.Value.DefaultHelpLink;
             }
-            catch { }
 
-            url ??= $"error:{MapTitle(response).ToSlug()}";
+            uri ??= new Uri($"error:{MapTitle(response).ToSlug()}");
 
-            return new Uri(url).ToString();
+            return uri.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -138,10 +138,19 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// Map the ProblemDetails.Type property using the HTTP response.
         /// </summary>
         /// <param name="response">The HTTP response.</param>
-        /// <returns>Returns the URI with the HTTP status name ("error:[status:slug]").</returns>
+        /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            return new Uri($"error:{MapTitle(response).ToSlug()}").ToString();
+            string url = null;
+            try
+            {
+                ((HttpStatusCode)response.StatusCode).TryGetLink(out url);
+            }
+            catch { }
+
+            url ??= $"error:{MapTitle(response).ToSlug()}";
+
+            return new Uri(url).ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions/HttpException.cs
+++ b/src/Opw.HttpExceptions/HttpException.cs
@@ -29,7 +29,6 @@ namespace Opw.HttpExceptions
                 if (!string.IsNullOrWhiteSpace(_helpLink)) return _helpLink;
                 if (StatusCode.TryGetLink(out var link)) return link;
                 return ResponseStatusCodeLink.InternalServerError;
-
             }
             set => _helpLink = value;
         }

--- a/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
+++ b/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
@@ -3,9 +3,17 @@ using System.Reflection;
 
 namespace Opw.HttpExceptions
 {
-    internal static class HttpStatusCodeExtensions
+    /// <summary>
+    /// Extension methods for HttpStatusCode.
+    /// </summary>
+    public static class HttpStatusCodeExtensions
     {
-        internal static bool TryGetLink(this HttpStatusCode statusCode, out string link)
+        /// <summary>
+        /// Try get a status code information link (https://tools.ietf.org/html/rfc7231).
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="link">The status code information link.</param>
+        public static bool TryGetLink(this HttpStatusCode statusCode, out string link)
         {
             try
             {

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -219,6 +219,25 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
             result.Should().Be("error:divide-by-zero");
         }
 
+        [Fact]
+        public void MapType_Should_ReturnExceptionHelpLink()
+        {
+            var helpLink = "https://docs.microsoft.com/en-us/dotnet/api/system.exception.helplink?view=netcore-2.2";
+            var exception = new ApplicationException { HelpLink = helpLink };
+            var result = _mapper.MapType(exception, new DefaultHttpContext());
+
+            result.Should().Be(helpLink);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnExceptionHelpLinkForHttpException()
+        {
+            var exception = new BadRequestException();
+            var result = _mapper.MapType(exception, new DefaultHttpContext());
+
+            result.Should().Be(exception.HelpLink);
+        }
+
         private class ExposeProtectedProblemDetailsExceptionMapper : ProblemDetailsExceptionMapper<Exception>
         {
             public ExposeProtectedProblemDetailsExceptionMapper(IOptions<HttpExceptionsOptions> options) : base(options) { }

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Moq;
 using System;
 using System.Net;
 using Xunit;
@@ -126,11 +127,62 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized()
+        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized_WhenUseHelpLinkAsProblemDetailsTypeTrue()
         {
-            var result = _mapper.MapType(_unauthorizedHttpContext.Response);
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true,
+                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+
+            var result = mapper.MapType(_unauthorizedHttpContext.Response);
 
             result.Should().Be(ResponseStatusCodeLink.Unauthorized);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnDefaultHelpLink_WhenUseHelpLinkAsProblemDetailsTypeTrue()
+        {
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true,
+                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("http://www.example.com/help-page");
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnTypeAsErrorUri_WhenUseHelpLinkAsProblemDetailsTypeTrueAndDefaultHelpLinkForProblemDetailsTypeNull()
+        {
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("error:418");
         }
 
         [Fact]

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -126,11 +126,23 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnFormattedHttpStatus()
+        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized()
         {
             var result = _mapper.MapType(_unauthorizedHttpContext.Response);
 
-            result.Should().Be("error:unauthorized");
+            result.Should().Be(ResponseStatusCodeLink.Unauthorized);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnFormattedHttpStatus()
+        {
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = _mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("error:418");
         }
 
         private class ExposeProtectedProblemDetailsHttpResponseMapper : ProblemDetailsHttpResponseMapper


### PR DESCRIPTION
Using RFC as ProblemDetails type #47

Updated the `ProblemDetailsExceptionMapper` to return the `Exception.HelpLink` or an URI with the Exception type name ("error:[Type:slug]").
And updated the `ProblemDetailsHttpResponseMapper` to return a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").

To use a help link for ProblemDetails type property is configurable in the options.
When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the `Exception.HelpLink` or the HTTP status code information link to map the `ProblemDetails.Type` property. And when you want to set a default link for your help pages, you can set `DefaultHelpLink`.

```
mvcBuilder.AddHttpExceptions(options =>
{
    options.UseHelpLinkAsProblemDetailsType = true;
    options.DefaultHelpLink = new Uri("http://www.example.com/help-page");
});
```