### PR TITLE
Use a helplink as the default for the ProblemDetails.Type property

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ mvcBuilder.AddHttpExceptions(options =>
 ```
 
 #### Use a help link for ProblemDetails type property
-When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
-And when you want to set a default link for your help pages, you can set `DefaultHelpLinkForProblemDetailsType`.
+When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the `Exception.HelpLink` or the HTTP status code information link to map the `ProblemDetails.Type` property.
+And when you want to set a default link for your help pages, you can set `DefaultHelpLink`.
 
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ mvcBuilder.AddHttpExceptions(options =>
 });
 ```
 
+#### Use a help link for ProblemDetails type property
+When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
+And when you want to set a default link for your help pages, you can set `DefaultHelpLinkForProblemDetailsType`.
+
+``` csharp
+mvcBuilder.AddHttpExceptions(options =>
+{
+    options.UseHelpLinkAsProblemDetailsType = true;
+    options.DefaultHelpLink = new Uri("http://www.example.com/help-page");
+});
+```
+
 #### Custom ExceptionMappers
 Set the ExceptionMapper collection that will be used during mapping. You can override and/or add ExceptionMappers for specific
 exception types. The ExceptionMappers are called in order so make sure you add them in the right order.

--- a/README.md
+++ b/README.md
@@ -85,14 +85,32 @@ mvcBuilder.AddHttpExceptions(options =>
 });
 ```
 
-#### Use a help link for ProblemDetails type property
-When `UseHelpLinkAsProblemDetailsType` is set to true the mappers uses the `Exception.HelpLink` or the HTTP status code information link to map the `ProblemDetails.Type` property.
-And when you want to set a default link for your help pages, you can set `DefaultHelpLink`.
+####  ProblemDetails type property
+By default the `ProblemDetails.Type` property will be set by:
+
+1. Either the `Exception.HelpLink` or the HTTP status code information link.
+2. Or the `DefaultHelpLink` will be used.
+3. Or an URI with the HTTP status name ("error:[status:slug]") will be used.
+
+You can override this behavior in the options, or by creating your own `IExceptionMapper` and/or `IHttpResponseMapper`.
 
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>
 {
+    ExceptionTypeMapping = exception => {
+        // This is the default behavior, you can implement your own logic here.
+        if (!string.IsNullOrWhiteSpace(ex.HelpLink))
+        {
+            try
+            {
+                return new Uri(ex.HelpLink);
+            }
+            catch { }
+        }
+        return null;
+    },
     HttpContextTypeMapping = context => {
+        // This is the default behavior, you can implement your own logic here.
         if (context.Response.StatusCode.TryGetInformationLink(out var url))
         {
             try
@@ -101,8 +119,9 @@ mvcBuilder.AddHttpExceptions(options =>
             }
             catch { }
         }
-        return new Uri("http://www.example.com/help-page");
-    }
+        return null;
+    },
+    DefaultHelpLink = new Uri("http://www.example.com/help-page")
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,17 @@ And when you want to set a default link for your help pages, you can set `Defaul
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>
 {
-    options.UseHelpLinkAsProblemDetailsType = true;
-    options.DefaultHelpLink = new Uri("http://www.example.com/help-page");
+    HttpContextTypeMapping = context => {
+        if (context.Response.StatusCode.TryGetInformationLink(out var url))
+        {
+            try
+            {
+                return new Uri(url);
+            }
+            catch { }
+        }
+        return new Uri("http://www.example.com/help-page");
+    }
 });
 ```
 

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -27,6 +27,17 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<Exception, bool> ShouldLogException { get; set; }
 
         /// <summary>
+        /// Use the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
+        /// </summary>
+        public bool UseHelpLinkAsProblemDetailsType { get; set; }
+
+        /// <summary>
+        /// If set, UseHelpLinkAsProblemDetailsType is TRUE and Exception.HelpLink or the HTTP status code information
+        /// link are empty this link will be used to map the ProblemDetails.Type property.
+        /// </summary>
+        public Uri DefaultHelpLink { get; set; }
+
+        /// <summary>
         /// Register of the ExceptionMappers that will be used during mapping.
         /// </summary>
         public IDictionary<Type, ExceptionMapperDescriptor> ExceptionMapperDescriptors { get; set; } = new Dictionary<Type, ExceptionMapperDescriptor>();

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -37,6 +37,12 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, Uri> HttpContextTypeMapping { get; set; }
 
         /// <summary>
+        /// A default help link that will be used to map the ProblemDetails.Type property, if the Exception.HelpLink
+        /// or the HTTP status code information link are empty.
+        /// </summary>
+        public Uri DefaultHelpLink { get; set; }
+
+        /// <summary>
         /// Register of the ExceptionMappers that will be used during mapping.
         /// </summary>
         public IDictionary<Type, ExceptionMapperDescriptor> ExceptionMapperDescriptors { get; set; } = new Dictionary<Type, ExceptionMapperDescriptor>();

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -27,15 +27,14 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<Exception, bool> ShouldLogException { get; set; }
 
         /// <summary>
-        /// Use the Exception.HelpLink or the HTTP status code information link to map the ProblemDetails.Type property.
+        /// Override the mapping of the ProblemDetails.Type property using the exception.
         /// </summary>
-        public bool UseHelpLinkAsProblemDetailsType { get; set; }
+        public Func<Exception, Uri> ExceptionTypeMapping { get; set; }
 
         /// <summary>
-        /// If set, UseHelpLinkAsProblemDetailsType is TRUE and Exception.HelpLink or the HTTP status code information
-        /// link are empty this link will be used to map the ProblemDetails.Type property.
+        /// Override the mapping of the ProblemDetails.Type property using the HTTP context.
         /// </summary>
-        public Uri DefaultHelpLink { get; set; }
+        public Func<HttpContext, Uri> HttpContextTypeMapping { get; set; }
 
         /// <summary>
         /// Register of the ExceptionMappers that will be used during mapping.

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
@@ -40,10 +40,10 @@ namespace Opw.HttpExceptions.AspNetCore
                 options.ShouldLogException = ShouldLogException;
 
             if (options.ExceptionTypeMapping == null)
-                options.ExceptionTypeMapping = _ => null;
+                options.ExceptionTypeMapping = ExceptionTypeMapping;
 
             if (options.HttpContextTypeMapping == null)
-                options.HttpContextTypeMapping = _ => null;
+                options.HttpContextTypeMapping = HttpContextTypeMapping;
 
             ConfigureExceptionMappers(options);
             ConfigureHttpResponseMappers(options);
@@ -71,6 +71,32 @@ namespace Opw.HttpExceptions.AspNetCore
         private static bool ShouldLogException(Exception ex)
         {
             return true;
+        }
+
+        private static Uri ExceptionTypeMapping(Exception ex)
+        {
+            if (!string.IsNullOrWhiteSpace(ex.HelpLink))
+            {
+                try
+                {
+                    return new Uri(ex.HelpLink);
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        private static Uri HttpContextTypeMapping(HttpContext context)
+        {
+            if (context.Response.StatusCode.TryGetInformationLink(out var url))
+            {
+                try
+                {
+                    return new Uri(url);
+                }
+                catch { }
+            }
+            return null;
         }
 
         private void ConfigureExceptionMappers(HttpExceptionsOptions options)

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
@@ -39,6 +39,12 @@ namespace Opw.HttpExceptions.AspNetCore
             if (options.ShouldLogException == null)
                 options.ShouldLogException = ShouldLogException;
 
+            if (options.ExceptionTypeMapping == null)
+                options.ExceptionTypeMapping = _ => null;
+
+            if (options.HttpContextTypeMapping == null)
+                options.HttpContextTypeMapping = _ => null;
+
             ConfigureExceptionMappers(options);
             ConfigureHttpResponseMappers(options);
         }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,7 +157,12 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            Uri uri = Options.Value.ExceptionTypeMapping(exception) ?? new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+            Uri uri = Options.Value.ExceptionTypeMapping(exception);
+            if (uri == null)
+                uri = Options.Value.DefaultHelpLink;
+            if (uri == null)
+                uri = new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+
             return uri.ToString();
         }
     }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -154,10 +154,11 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <param name="context">The HTTP context.</param>
-        /// <returns>Returns the URI with the Exception type name ("error:[Type:slug]").</returns>
+        /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            return new Uri($"error:{MapTitle(exception, context).ToSlug()}").ToString();
+            var url = exception.HelpLink ?? $"error:{MapTitle(exception, context).ToSlug()}";
+            return new Uri(url).ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,23 +157,7 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            Uri uri = null;
-            if (Options.Value.UseHelpLinkAsProblemDetailsType)
-            {
-                if (!string.IsNullOrWhiteSpace(exception.HelpLink))
-                {
-                    try
-                    {
-                        uri = new Uri(exception.HelpLink);
-                    }
-                    catch { }
-                }
-
-                uri ??= Options.Value.DefaultHelpLink;
-            }
-
-            uri ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
-
+            Uri uri = Options.Value.ExceptionTypeMapping(exception) ?? new Uri($"error:{MapTitle(exception, context).ToSlug()}");
             return uri.ToString();
         }
     }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,19 +157,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            Uri link = null;
-            if (!string.IsNullOrWhiteSpace(exception.HelpLink))
+            Uri uri = null;
+            if (Options.Value.UseHelpLinkAsProblemDetailsType)
             {
-                try
+                if (!string.IsNullOrWhiteSpace(exception.HelpLink))
                 {
-                    link = new Uri(exception.HelpLink);
+                    try
+                    {
+                        uri = new Uri(exception.HelpLink);
+                    }
+                    catch { }
                 }
-                catch { }
+
+                uri ??= Options.Value.DefaultHelpLink;
             }
 
-            link ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+            uri ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
 
-            return link.ToString();
+            return uri.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -157,8 +157,19 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            var url = exception.HelpLink ?? $"error:{MapTitle(exception, context).ToSlug()}";
-            return new Uri(url).ToString();
+            Uri link = null;
+            if (!string.IsNullOrWhiteSpace(exception.HelpLink))
+            {
+                try
+                {
+                    link = new Uri(exception.HelpLink);
+                }
+                catch { }
+            }
+
+            link ??= new Uri($"error:{MapTitle(exception, context).ToSlug()}");
+
+            return link.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -141,16 +141,22 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            string url = null;
-            try
+            Uri uri = null;
+            if (Options.Value.UseHelpLinkAsProblemDetailsType)
             {
-                ((HttpStatusCode)response.StatusCode).TryGetLink(out url);
+                try
+                {
+                    ((HttpStatusCode)response.StatusCode).TryGetLink(out var url);
+                    uri = new Uri(url);
+                }
+                catch { }
+
+                uri ??= Options.Value.DefaultHelpLink;
             }
-            catch { }
 
-            url ??= $"error:{MapTitle(response).ToSlug()}";
+            uri ??= new Uri($"error:{MapTitle(response).ToSlug()}");
 
-            return new Uri(url).ToString();
+            return uri.ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -141,7 +141,11 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            Uri uri = Options.Value.HttpContextTypeMapping(response.HttpContext) ?? new Uri($"error:{MapTitle(response).ToSlug()}");
+            Uri uri = Options.Value.HttpContextTypeMapping(response.HttpContext);
+            if (uri == null)
+                uri = Options.Value.DefaultHelpLink;
+            if (uri == null)
+                uri = new Uri($"error:{MapTitle(response).ToSlug()}");
             return uri.ToString();
         }
     }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -138,10 +138,19 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// Map the ProblemDetails.Type property using the HTTP response.
         /// </summary>
         /// <param name="response">The HTTP response.</param>
-        /// <returns>Returns the URI with the HTTP status name ("error:[status:slug]").</returns>
+        /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            return new Uri($"error:{MapTitle(response).ToSlug()}").ToString();
+            string url = null;
+            try
+            {
+                ((HttpStatusCode)response.StatusCode).TryGetLink(out url);
+            }
+            catch { }
+
+            url ??= $"error:{MapTitle(response).ToSlug()}";
+
+            return new Uri(url).ToString();
         }
     }
 }

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -141,21 +141,7 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns a status code information link (https://tools.ietf.org/html/rfc7231) or the URI with the HTTP status name ("error:[status:slug]").</returns>
         protected virtual string MapType(HttpResponse response)
         {
-            Uri uri = null;
-            if (Options.Value.UseHelpLinkAsProblemDetailsType)
-            {
-                try
-                {
-                    ((HttpStatusCode)response.StatusCode).TryGetLink(out var url);
-                    uri = new Uri(url);
-                }
-                catch { }
-
-                uri ??= Options.Value.DefaultHelpLink;
-            }
-
-            uri ??= new Uri($"error:{MapTitle(response).ToSlug()}");
-
+            Uri uri = Options.Value.HttpContextTypeMapping(response.HttpContext) ?? new Uri($"error:{MapTitle(response).ToSlug()}");
             return uri.ToString();
         }
     }

--- a/src/Opw.HttpExceptions/HttpException.cs
+++ b/src/Opw.HttpExceptions/HttpException.cs
@@ -27,7 +27,7 @@ namespace Opw.HttpExceptions
             get
             {
                 if (!string.IsNullOrWhiteSpace(_helpLink)) return _helpLink;
-                if (StatusCode.TryGetLink(out var link)) return link;
+                if (StatusCode.TryGetInformationLink(out var link)) return link;
                 return ResponseStatusCodeLink.InternalServerError;
             }
             set => _helpLink = value;

--- a/src/Opw.HttpExceptions/HttpException.cs
+++ b/src/Opw.HttpExceptions/HttpException.cs
@@ -29,7 +29,6 @@ namespace Opw.HttpExceptions
                 if (!string.IsNullOrWhiteSpace(_helpLink)) return _helpLink;
                 if (StatusCode.TryGetLink(out var link)) return link;
                 return ResponseStatusCodeLink.InternalServerError;
-
             }
             set => _helpLink = value;
         }

--- a/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
+++ b/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
@@ -13,7 +13,24 @@ namespace Opw.HttpExceptions
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="link">The status code information link.</param>
-        public static bool TryGetLink(this HttpStatusCode statusCode, out string link)
+        public static bool TryGetInformationLink(this int statusCode, out string link)
+        {
+            try
+            {
+                return ((HttpStatusCode)statusCode).TryGetInformationLink(out link);
+            }
+            catch { }
+
+            link = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Try get a status code information link (https://tools.ietf.org/html/rfc7231).
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="link">The status code information link.</param>
+        public static bool TryGetInformationLink(this HttpStatusCode statusCode, out string link)
         {
             try
             {

--- a/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
+++ b/src/Opw.HttpExceptions/HttpStatusCodeExtensions.cs
@@ -3,9 +3,17 @@ using System.Reflection;
 
 namespace Opw.HttpExceptions
 {
-    internal static class HttpStatusCodeExtensions
+    /// <summary>
+    /// Extension methods for HttpStatusCode.
+    /// </summary>
+    public static class HttpStatusCodeExtensions
     {
-        internal static bool TryGetLink(this HttpStatusCode statusCode, out string link)
+        /// <summary>
+        /// Try get a status code information link (https://tools.ietf.org/html/rfc7231).
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="link">The status code information link.</param>
+        public static bool TryGetLink(this HttpStatusCode statusCode, out string link)
         {
             try
             {

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -219,6 +219,25 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
             result.Should().Be("error:divide-by-zero");
         }
 
+        [Fact]
+        public void MapType_Should_ReturnExceptionHelpLink()
+        {
+            var helpLink = "https://docs.microsoft.com/en-us/dotnet/api/system.exception.helplink?view=netcore-2.2";
+            var exception = new ApplicationException { HelpLink = helpLink };
+            var result = _mapper.MapType(exception, new DefaultHttpContext());
+
+            result.Should().Be(helpLink);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnExceptionHelpLinkForHttpException()
+        {
+            var exception = new BadRequestException();
+            var result = _mapper.MapType(exception, new DefaultHttpContext());
+
+            result.Should().Be(exception.HelpLink);
+        }
+
         private class ExposeProtectedProblemDetailsExceptionMapper : ProblemDetailsExceptionMapper<Exception>
         {
             public ExposeProtectedProblemDetailsExceptionMapper(IOptions<HttpExceptionsOptions> options) : base(options) { }

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -221,6 +221,15 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapType_Should_ReturnDefaultHelpLink_UsingDefaultExceptionTypeMapping_WhenExceptionHelpLinkIsNoValidUri()
+        {
+            var exception = new ApplicationException { HelpLink = "invalid-link" };
+            var result = _mapper.MapType(exception, new DefaultHttpContext());
+
+            result.Should().Be("http://www.example.com/help-page");
+        }
+
+        [Fact]
         public void MapType_Should_ReturnHttpStatusCodeInformationLink_UsingDefaultExceptionTypeMapping_ForHttpException()
         {
             var exception = new BadRequestException();

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -127,12 +127,21 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized_WhenUseHelpLinkAsProblemDetailsTypeTrue()
+        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized_UsingHttpContextTypeMapping()
         {
             var options = new HttpExceptionsOptions
             {
-                UseHelpLinkAsProblemDetailsType = true,
-                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+                HttpContextTypeMapping = context => {
+                    if (context.Response.StatusCode.TryGetInformationLink(out var url))
+                    {
+                        try
+                        {
+                            return new Uri(url);
+                        }
+                        catch { }
+                    }
+                    return new Uri("http://www.example.com/help-page");
+                }
             };
             var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
             optionsMock.Setup(o => o.Value).Returns(options);
@@ -145,12 +154,21 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnDefaultHelpLink_WhenUseHelpLinkAsProblemDetailsTypeTrue()
+        public void MapType_Should_ReturnDefaultHelpLink_UsingHttpContextTypeMapping()
         {
             var options = new HttpExceptionsOptions
             {
-                UseHelpLinkAsProblemDetailsType = true,
-                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+                HttpContextTypeMapping = context => {
+                    if (context.Response.StatusCode.TryGetInformationLink(out var url))
+                    {
+                        try
+                        {
+                            return new Uri(url);
+                        }
+                        catch { }
+                    }
+                    return new Uri("http://www.example.com/help-page");
+                }
             };
             var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
             optionsMock.Setup(o => o.Value).Returns(options);
@@ -166,11 +184,12 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnTypeAsErrorUri_WhenUseHelpLinkAsProblemDetailsTypeTrueAndDefaultHelpLinkForProblemDetailsTypeNull()
+        public void MapType_Should_ReturnTypeAsErrorUri_WhenNotUsingHttpContextTypeMapping()
         {
             var options = new HttpExceptionsOptions
             {
-                UseHelpLinkAsProblemDetailsType = true
+                // simulate the HttpExceptionsOptionsSetup
+                HttpContextTypeMapping = _ => null
             };
             var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
             optionsMock.Setup(o => o.Value).Returns(options);

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Moq;
 using System;
 using System.Net;
 using Xunit;
@@ -126,11 +127,62 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized()
+        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized_WhenUseHelpLinkAsProblemDetailsTypeTrue()
         {
-            var result = _mapper.MapType(_unauthorizedHttpContext.Response);
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true,
+                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+
+            var result = mapper.MapType(_unauthorizedHttpContext.Response);
 
             result.Should().Be(ResponseStatusCodeLink.Unauthorized);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnDefaultHelpLink_WhenUseHelpLinkAsProblemDetailsTypeTrue()
+        {
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true,
+                DefaultHelpLink = new Uri("http://www.example.com/help-page")
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("http://www.example.com/help-page");
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnTypeAsErrorUri_WhenUseHelpLinkAsProblemDetailsTypeTrueAndDefaultHelpLinkForProblemDetailsTypeNull()
+        {
+            var options = new HttpExceptionsOptions
+            {
+                UseHelpLinkAsProblemDetailsType = true
+            };
+            var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();
+            optionsMock.Setup(o => o.Value).Returns(options);
+
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(optionsMock.Object);
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("error:418");
         }
 
         [Fact]

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -126,11 +126,23 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
-        public void MapType_Should_ReturnFormattedHttpStatus()
+        public void MapType_Should_ReturnResponseStatusCodeLinkUnauthorized()
         {
             var result = _mapper.MapType(_unauthorizedHttpContext.Response);
 
-            result.Should().Be("error:unauthorized");
+            result.Should().Be(ResponseStatusCodeLink.Unauthorized);
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnFormattedHttpStatus()
+        {
+            var teapotHttpContext = new DefaultHttpContext();
+            teapotHttpContext.Request.Path = "/api/test/i-am-a-teapot";
+            teapotHttpContext.Response.StatusCode = 418;
+
+            var result = _mapper.MapType(teapotHttpContext.Response);
+
+            result.Should().Be("error:418");
         }
 
         private class ExposeProtectedProblemDetailsHttpResponseMapper : ProblemDetailsHttpResponseMapper

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
@@ -14,10 +14,14 @@ namespace Opw.HttpExceptions.AspNetCore
             webHost.Services.GetRequiredService<IWebHostEnvironment>().EnvironmentName = environmentName;
         }
 
-        public static Mock<IOptions<HttpExceptionsOptions>> CreateHttpExceptionsOptionsMock(bool includeExceptionDetails)
+        public static Mock<IOptions<HttpExceptionsOptions>> CreateHttpExceptionsOptionsMock(bool includeExceptionDetails, Uri defaultHelpLink = null)
         {
             var services = new ServiceCollection();
-            services.AddHttpExceptions(options => options.IncludeExceptionDetails = (_) => includeExceptionDetails);
+            services.AddHttpExceptions(options =>
+            {
+                options.IncludeExceptionDetails = (_) => includeExceptionDetails;
+                options.DefaultHelpLink = defaultHelpLink;
+            });
             
             var serviceProvider = services.BuildServiceProvider();
 

--- a/tests/Opw.HttpExceptions.Tests/HttpStatusCodeExtensionsTests.cs
+++ b/tests/Opw.HttpExceptions.Tests/HttpStatusCodeExtensionsTests.cs
@@ -7,18 +7,27 @@ namespace Opw.HttpExceptions
     public class HttpStatusCodeExtensionsTests
     {
         [Fact]
-        public void TryGetLink_Should_ReturnLink_ForInternalServerError()
+        public void TryGetInformationLink_Should_ReturnLink_ForInternalServerError()
         {
-            var result = HttpStatusCode.InternalServerError.TryGetLink(out var link);
+            var result = HttpStatusCode.InternalServerError.TryGetInformationLink(out var link);
 
             result.Should().BeTrue();
             link.Should().Be(ResponseStatusCodeLink.InternalServerError);
         }
 
         [Fact]
-        public void TryGetLink_Should_ReturnFalse_ForOK()
+        public void TryGetInformationLink_Should_ReturnLink_ForInternalServerErrorAsInt()
         {
-            var result = HttpStatusCode.OK.TryGetLink(out var link);
+            var result = ((int)HttpStatusCode.InternalServerError).TryGetInformationLink(out var link);
+
+            result.Should().BeTrue();
+            link.Should().Be(ResponseStatusCodeLink.InternalServerError);
+        }
+
+        [Fact]
+        public void TryGetInformationLink_Should_ReturnFalse_ForOK()
+        {
+            var result = HttpStatusCode.OK.TryGetInformationLink(out var link);
 
             result.Should().BeFalse();
         }


### PR DESCRIPTION
Use a helplink as the default for the ProblemDetails.Type property #49

Use a helplink as the default for the ProblemDetails.Type property.

- Use the Exception.HelpLink for exceptions
- Use the Http status code information link for http responses

Make them configurable through the options by a function, like IsExceptionResponse.

> this is a breaking change so bump the version to 3.0