### PR TITLE
Add the option to override the `MapInstance` methods on the mappers from a `Func` on the options. #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,43 +85,28 @@ mvcBuilder.AddHttpExceptions(options =>
 });
 ```
 
-####  ProblemDetails type property
-By default the `ProblemDetails.Type` property will be set by:
+####  ProblemDetails property mappings
+You can override the mapping for the `ProblemDetails` properties using functions on the `HttpExceptionsOptions`, or by creating your own `IExceptionMapper` and/or `IHttpResponseMapper`.
+
+In the following example we'll override the `ProblemDetails.Type` property. By default the `ProblemDetails.Type` property will be set by:
 
 1. Either the `Exception.HelpLink` or the HTTP status code information link.
 2. Or the `DefaultHelpLink` will be used.
 3. Or an URI with the HTTP status name ("error:[status:slug]") will be used.
 
-You can override this behavior in the options, or by creating your own `IExceptionMapper` and/or `IHttpResponseMapper`.
+When the `ExceptionTypeMapping` or `HttpContextTypeMapping` are set the result of those functions will be used.
 
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>
 {
     ExceptionTypeMapping = exception => {
-        // This is the default behavior, you can implement your own logic here.
-        if (!string.IsNullOrWhiteSpace(ex.HelpLink))
-        {
-            try
-            {
-                return new Uri(ex.HelpLink);
-            }
-            catch { }
-        }
-        return null;
+        // This is a example, you can implement your own logic here.
+        return "My Exception Type Mapping";
     },
     HttpContextTypeMapping = context => {
-        // This is the default behavior, you can implement your own logic here.
-        if (context.Response.StatusCode.TryGetInformationLink(out var url))
-        {
-            try
-            {
-                return new Uri(url);
-            }
-            catch { }
-        }
-        return null;
-    },
-    DefaultHelpLink = new Uri("http://www.example.com/help-page")
+        // This is a example, you can implement your own logic here.
+        return "My  HttpContext Type Mapping";
+    }
 });
 ```
 

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -37,6 +37,16 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, Uri> HttpContextTypeMapping { get; set; }
 
         /// <summary>
+        /// Override the mapping of the ProblemDetails.Instance property using the exception.
+        /// </summary>
+        public Func<Exception, string> ExceptionInstanceMapping { get; set; }
+
+        /// <summary>
+        /// Override the mapping of the ProblemDetails.Instance property using the HTTP context.
+        /// </summary>
+        public Func<HttpContext, string> HttpContextInstanceMapping { get; set; }
+
+        /// <summary>
         /// A default help link that will be used to map the ProblemDetails.Type property, if the Exception.HelpLink
         /// or the HTTP status code information link are empty.
         /// </summary>

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptionsSetup.cs
@@ -39,12 +39,6 @@ namespace Opw.HttpExceptions.AspNetCore
             if (options.ShouldLogException == null)
                 options.ShouldLogException = ShouldLogException;
 
-            if (options.ExceptionTypeMapping == null)
-                options.ExceptionTypeMapping = ExceptionTypeMapping;
-
-            if (options.HttpContextTypeMapping == null)
-                options.HttpContextTypeMapping = HttpContextTypeMapping;
-
             ConfigureExceptionMappers(options);
             ConfigureHttpResponseMappers(options);
         }
@@ -71,32 +65,6 @@ namespace Opw.HttpExceptions.AspNetCore
         private static bool ShouldLogException(Exception ex)
         {
             return true;
-        }
-
-        private static Uri ExceptionTypeMapping(Exception ex)
-        {
-            if (!string.IsNullOrWhiteSpace(ex.HelpLink))
-            {
-                try
-                {
-                    return new Uri(ex.HelpLink);
-                }
-                catch { }
-            }
-            return null;
-        }
-
-        private static Uri HttpContextTypeMapping(HttpContext context)
-        {
-            if (context.Response.StatusCode.TryGetInformationLink(out var url))
-            {
-                try
-                {
-                    return new Uri(url);
-                }
-                catch { }
-            }
-            return null;
         }
 
         private void ConfigureExceptionMappers(HttpExceptionsOptions options)

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -95,6 +95,13 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns either the request path, the exception help link or null.</returns>
         protected virtual string MapInstance(TException exception, HttpContext context)
         {
+            if (Options.Value.ExceptionInstanceMapping != null)
+            {
+                string instance = Options.Value.ExceptionInstanceMapping(exception);
+                if (!string.IsNullOrEmpty(instance))
+                    return instance;
+            }
+
             if (context.Request?.Path.HasValue == true)
                 return context.Request.Path;
 
@@ -157,7 +164,20 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception.HelpLink or an URI with the Exception type name ("error:[Type:slug]").</returns>
         protected virtual string MapType(TException exception, HttpContext context)
         {
-            Uri uri = Options.Value.ExceptionTypeMapping(exception);
+            Uri uri = null;
+
+            if (Options.Value.ExceptionTypeMapping != null)
+                uri = Options.Value.ExceptionTypeMapping(exception);
+
+            if (uri == null && !string.IsNullOrWhiteSpace(exception.HelpLink))
+            {
+                try
+                {
+                    uri = new Uri(exception.HelpLink);
+                }
+                catch { }
+            }
+
             if (uri == null)
                 uri = Options.Value.DefaultHelpLink;
             if (uri == null)

--- a/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.IntegrationTests/Opw.HttpExceptions.AspNetCore.IntegrationTests.csproj
@@ -11,10 +11,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.10.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Sample.Tests/Opw.HttpExceptions.AspNetCore.Sample.Tests.csproj
@@ -11,10 +11,10 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.10.2" />        
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />        
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -162,6 +162,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapInstance_Should_ReturnUri_UsingOptionsExceptionInstanceMappingOverride()
+        {
+            var uri = "https://example.com/ExceptionInstanceMapping";
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.ExceptionInstanceMapping = (Exception ex) =>
+            {
+                return uri;
+            };
+            var mapper = new ExposeProtectedProblemDetailsExceptionMapper(options);
+
+            var result = mapper.MapInstance(new ApplicationException(), new DefaultHttpContext());
+
+            result.Should().Be(uri);
+        }
+
+        [Fact]
         public void MapInstance_Should_ReturnExceptionHelpLink()
         {
             var helpLink = "https://docs.microsoft.com/en-us/dotnet/api/system.exception.helplink?view=netcore-2.2";
@@ -208,6 +226,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
             var result = _mapper.MapTitle(exception, new DefaultHttpContext());
 
             result.Should().Be("DivideByZero");
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnUri_UsingOptionsExceptionTypeMappingOverride()
+        {
+            var uri = new Uri("https://example.com/ExceptionTypeMapping");
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.ExceptionTypeMapping = (Exception ex) =>
+            {
+                return uri;
+            };
+            var mapper = new ExposeProtectedProblemDetailsExceptionMapper(options);
+
+            var result = mapper.MapType(new ApplicationException(), new DefaultHttpContext());
+
+            result.Should().Be(uri.ToString());
         }
 
         [Fact]

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using Moq;
 using System;
 using System.Net;
 using Xunit;
@@ -103,6 +102,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapInstance_Should_ReturnUri_UsingOptionsHttpContextInstanceMappingOverride()
+        {
+            var uri = "https://example.com/HttpContextInstanceMapping";
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.HttpContextInstanceMapping = (HttpContext context) =>
+            {
+                return uri;
+            };
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(options);
+
+            var result = mapper.MapInstance(new DefaultHttpContext().Response);
+
+            result.Should().Be(uri);
+        }
+
+        [Fact]
         public void MapInstance_Should_ReturnRequestPath()
         {
             var result = _mapper.MapInstance(_unauthorizedHttpContext.Response);
@@ -124,6 +141,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
             var result = _mapper.MapTitle(_unauthorizedHttpContext.Response);
 
             result.Should().Be("Unauthorized");
+        }
+
+        [Fact]
+        public void MapType_Should_ReturnUri_UsingOptionsHttpContextTypeMappingOverride()
+        {
+            var uri = new Uri("https://example.com/HttpContextTypeMapping");
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.HttpContextTypeMapping = (HttpContext context) =>
+            {
+                return uri;
+            };
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(options);
+
+            var result = mapper.MapType(new DefaultHttpContext().Response);
+
+            result.Should().Be(uri.ToString());
         }
 
         [Fact]

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
@@ -1,32 +1,36 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <RootNamespace>Opw.HttpExceptions.AspNetCore</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Opw.HttpExceptions.AspNetCore</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.10.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="Moq" Version="4.13.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Opw.HttpExceptions.AspNetCore\Opw.HttpExceptions.AspNetCore.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Opw.HttpExceptions.AspNetCore\Opw.HttpExceptions.AspNetCore.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/TestHelper.cs
@@ -22,7 +22,7 @@ namespace Opw.HttpExceptions.AspNetCore
                 options.IncludeExceptionDetails = (_) => includeExceptionDetails;
                 options.DefaultHelpLink = defaultHelpLink;
             });
-            
+
             var serviceProvider = services.BuildServiceProvider();
 
             var optionsMock = new Mock<IOptions<HttpExceptionsOptions>>();

--- a/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
+++ b/tests/Opw.HttpExceptions.Tests/Opw.HttpExceptions.Tests.csproj
@@ -11,10 +11,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
closes: #56 