### PR TITLE
Add the option to override the `MapTitle` methods on the mappers from a `Func` on the options. #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ mvcBuilder.AddHttpExceptions(options =>
 ```
 
 ####  ProblemDetails property mappings
-You can override the mapping for the `ProblemDetails` properties using functions on the `HttpExceptionsOptions`, or by creating your own `IExceptionMapper` and/or `IHttpResponseMapper`.
+You can inject your own mappings for the `ProblemDetails` properties using functions on the `HttpExceptionsOptions`, or by creating your own `IExceptionMapper` and/or `IHttpResponseMapper`. If you inject your own function that will be tried first, and if no result is returned the defaults will be used.
 
-In the following example we'll override the `ProblemDetails.Type` property. By default the `ProblemDetails.Type` property will be set by:
+In the following example we will override the `ProblemDetails.Type` property. By default the `ProblemDetails.Type` property will be set by:
 
 1. Either the `Exception.HelpLink` or the HTTP status code information link.
 2. Or the `DefaultHelpLink` will be used.
 3. Or an URI with the HTTP status name ("error:[status:slug]") will be used.
 
-When the `ExceptionTypeMapping` or `HttpContextTypeMapping` are set the result of those functions will be used.
+When the `ExceptionTypeMapping` or `HttpContextTypeMapping` are set the result of those functions will be tried first, if no result is returned the defaults will be used.
 
 ``` csharp
 mvcBuilder.AddHttpExceptions(options =>

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -47,6 +47,16 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, string> HttpContextInstanceMapping { get; set; }
 
         /// <summary>
+        /// Override the mapping of the ProblemDetails.Title property using the exception.
+        /// </summary>
+        public Func<Exception, string> ExceptionTitleMapping { get; set; }
+
+        /// <summary>
+        /// Override the mapping of the ProblemDetails.Title property using the HTTP context.
+        /// </summary>
+        public Func<HttpContext, string> HttpContextTitleMapping { get; set; }
+
+        /// <summary>
         /// A default help link that will be used to map the ProblemDetails.Type property, if the Exception.HelpLink
         /// or the HTTP status code information link are empty.
         /// </summary>

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -137,7 +137,16 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the Exception type name without the "Exception" suffix.</returns>
         protected virtual string MapTitle(TException exception, HttpContext context)
         {
-            var name = exception.GetType().Name;
+            string name = null;
+
+            if (Options.Value.ExceptionTitleMapping != null)
+            {
+                name = Options.Value.ExceptionTitleMapping(exception);
+                if (!string.IsNullOrEmpty(name))
+                    return name;
+            }
+
+            name = exception.GetType().Name;
             if (name.Contains("`")) name = name.Substring(0, name.IndexOf('`'));
             if (name.EndsWith("Exception", StringComparison.InvariantCultureIgnoreCase))
                 name = name.Substring(0, name.Length - "Exception".Length);

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -121,7 +121,16 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the HTTP status name or the status code.</returns>
         protected virtual string MapTitle(HttpResponse response)
         {
-            var status = response.StatusCode.ToString();
+            string status = null;
+
+            if (Options.Value.HttpContextTitleMapping != null)
+            {
+                status = Options.Value.HttpContextTitleMapping(response.HttpContext);
+                if (!string.IsNullOrEmpty(status))
+                    return status;
+            }
+
+            status = response.StatusCode.ToString();
             try
             {
                 status = ((HttpStatusCode)response.StatusCode).ToString();

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -220,6 +220,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapTitle_Should_ReturTitle_UsingOptionsExceptionTitleMappingOverride()
+        {
+            var title = "ExceptionTitleMapping";
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.ExceptionTitleMapping = (Exception ex) =>
+            {
+                return title;
+            };
+            var mapper = new ExposeProtectedProblemDetailsExceptionMapper(options);
+
+            var result = mapper.MapTitle(new ApplicationException(), new DefaultHttpContext());
+
+            result.Should().Be(title);
+        }
+
+        [Fact]
         public void MapTitle_Should_ReturnFormattedExceptionName()
         {
             var exception = new DivideByZeroException();

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -136,6 +136,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapTitle_Should_ReturnUri_UsingOptionsHttpContextTitleMappingOverride()
+        {
+            var title = "HttpContextTitleMapping";
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.HttpContextTitleMapping = (HttpContext context) =>
+            {
+                return title;
+            };
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(options);
+
+            var result = mapper.MapTitle(new DefaultHttpContext().Response);
+
+            result.Should().Be(title);
+        }
+
+        [Fact]
         public void MapTitle_Should_ReturnHttpStatus()
         {
             var result = _mapper.MapTitle(_unauthorizedHttpContext.Response);

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Opw.HttpExceptions.AspNetCore.Tests.csproj
@@ -22,10 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
closes #55