### PR TITLE
Add the option to override the `MapStatus` methods on the mappers from a `Func` on the options. #54

### DIFF
--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -27,42 +27,42 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<Exception, bool> ShouldLogException { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Type property using the exception.
+        /// Inject a function to map the ProblemDetails.Type property using the exception.
         /// </summary>
         public Func<Exception, Uri> ExceptionTypeMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Type property using the HTTP context.
+        /// Inject a function to map the ProblemDetails.Type property using the HTTP context.
         /// </summary>
         public Func<HttpContext, Uri> HttpContextTypeMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Instance property using the exception.
+        /// Inject a function to map the ProblemDetails.Instance property using the exception.
         /// </summary>
         public Func<Exception, string> ExceptionInstanceMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Instance property using the HTTP context.
+        /// Inject a function to map the ProblemDetails.Instance property using the HTTP context.
         /// </summary>
         public Func<HttpContext, string> HttpContextInstanceMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Title property using the exception.
+        /// Inject a function to map the ProblemDetails.Title property using the exception.
         /// </summary>
         public Func<Exception, string> ExceptionTitleMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Title property using the HTTP context.
+        /// Inject a function to map the ProblemDetails.Title property using the HTTP context.
         /// </summary>
         public Func<HttpContext, string> HttpContextTitleMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Status property using the exception.
+        /// Inject a function to map the ProblemDetails.Status property using the exception.
         /// </summary>
         public Func<Exception, int?> ExceptionStatusMapping { get; set; }
 
         /// <summary>
-        /// Override the mapping of the ProblemDetails.Status property using the HTTP context.
+        /// Inject a function to map the ProblemDetails.Status property using the HTTP context.
         /// </summary>
         public Func<HttpContext, int?> HttpContextStatusMapping { get; set; }
 

--- a/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/HttpExceptionsOptions.cs
@@ -57,6 +57,16 @@ namespace Opw.HttpExceptions.AspNetCore
         public Func<HttpContext, string> HttpContextTitleMapping { get; set; }
 
         /// <summary>
+        /// Override the mapping of the ProblemDetails.Status property using the exception.
+        /// </summary>
+        public Func<Exception, int?> ExceptionStatusMapping { get; set; }
+
+        /// <summary>
+        /// Override the mapping of the ProblemDetails.Status property using the HTTP context.
+        /// </summary>
+        public Func<HttpContext, int?> HttpContextStatusMapping { get; set; }
+
+        /// <summary>
         /// A default help link that will be used to map the ProblemDetails.Type property, if the Exception.HelpLink
         /// or the HTTP status code information link are empty.
         /// </summary>

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsExceptionMapper.cs
@@ -123,6 +123,13 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the HttpException status code or 500 (InternalServerError) for other exception types.</returns>
         protected virtual int MapStatus(TException exception, HttpContext context)
         {
+            if (Options.Value.ExceptionStatusMapping != null)
+            {
+                int? status = Options.Value.ExceptionStatusMapping(exception);
+                if (status.HasValue)
+                    return status.Value;
+            }
+
             if (exception is HttpExceptionBase httpException)
                 return (int)httpException.StatusCode;
 

--- a/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
+++ b/src/Opw.HttpExceptions.AspNetCore/Mappers/ProblemDetailsHttpResponseMapper.cs
@@ -111,6 +111,13 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         /// <returns>Returns the status of the response.</returns>
         protected virtual int MapStatus(HttpResponse response)
         {
+            if (Options.Value.HttpContextStatusMapping != null)
+            {
+                int? status = Options.Value.HttpContextStatusMapping(response.HttpContext);
+                if (status.HasValue)
+                    return status.Value;
+            }
+
             return response.StatusCode;
         }
 

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsExceptionMapperTests.cs
@@ -202,6 +202,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapStatus_Should_ReturnStatus_UsingOptionsExceptionStatusMappingOverride()
+        {
+            int? status = 9999999;
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.ExceptionStatusMapping = (Exception ex) =>
+            {
+                return status;
+            };
+            var mapper = new ExposeProtectedProblemDetailsExceptionMapper(options);
+
+            var result = mapper.MapStatus(new ApplicationException(), new DefaultHttpContext());
+
+            result.Should().Be(status);
+        }
+
+        [Fact]
         public void MapStatus_Should_ReturnInternalServerError()
         {
             var exception = new ApplicationException();

--- a/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
+++ b/tests/Opw.HttpExceptions.AspNetCore.Tests/Mappers/ProblemDetailsHttpResponseMapperTests.cs
@@ -128,6 +128,24 @@ namespace Opw.HttpExceptions.AspNetCore.Mappers
         }
 
         [Fact]
+        public void MapStatus_Should_ReturnStatus_UsingOptionsHttpContextStatusMappingOverride()
+        {
+            int? status = 9999999;
+
+            var optionsMock = TestHelper.CreateHttpExceptionsOptionsMock(false, new Uri("http://www.example.com/help-page"));
+            var options = optionsMock.Object;
+            options.Value.HttpContextStatusMapping = (HttpContext context) =>
+            {
+                return status;
+            };
+            var mapper = new ExposeProtectedProblemDetailsHttpResponseMapper(options);
+
+            var result = mapper.MapStatus(new DefaultHttpContext().Response);
+
+            result.Should().Be(status);
+        }
+
+        [Fact]
         public void MapStatus_Should_ReturnUnauthorized()
         {
             var result = _mapper.MapStatus(_unauthorizedHttpContext.Response);


### PR DESCRIPTION
close #54 