### PR TITLE
Fixed adding the same keys to serializable exception data

### DIFF
--- a/src/Opw.HttpExceptions/SerializableException.cs
+++ b/src/Opw.HttpExceptions/SerializableException.cs
@@ -87,7 +87,7 @@ namespace Opw.HttpExceptions
             foreach (var propertyInfo in exception.GetType().GetProperties())//.Where(p => p.GetCustomAttributes(typeof(ProblemDetailsAttribute), true)?.Any() != true))
             {
                 if (propertiesToExclude.Any(p => p == propertyInfo.Name)) continue;
-                if (propertyInfo.CanRead)
+                if (propertyInfo.CanRead && !Data.ContainsKey(propertyInfo.Name))
                     Data.Add(propertyInfo.Name, propertyInfo.GetValue(exception));
             }
         }

--- a/tests/Opw.HttpExceptions.Tests/SerializableExceptionTests.cs
+++ b/tests/Opw.HttpExceptions.Tests/SerializableExceptionTests.cs
@@ -30,5 +30,41 @@ namespace Opw.HttpExceptions
             exception.InnerException.Type.Should().StartWith("ArgumentNullException");
             exception.InnerException.Data["ParamName"].Should().Be("param");
         }
+        
+        [Fact]
+        public void Serialization_Should_SerializeWithMultiplyPropertiesWithSameKey()
+        {
+            var somePropertyValue = "SomePropertyValue";
+            var overriddenException = new OverriddenException("OverriddenException")
+            {
+                SomeProperty = somePropertyValue
+            };
+            ((BaseException)overriddenException).SomeProperty = "another string";
+
+            var exception = new SerializableException(overriddenException);
+            exception = SerializationHelper.SerializeDeserialize(exception);
+
+            exception.Type.Should().Be("OverriddenException");
+            exception.Message.Should().Be("OverriddenException");
+            exception.Data["SomeProperty"].Should().Be(somePropertyValue);
+        }
+
+        private class BaseException : Exception
+        {
+            public string SomeProperty { get; set; }
+
+            public BaseException(string message) : base(message)
+            {
+            }
+        }
+
+        private class OverriddenException : BaseException
+        {
+            public new object SomeProperty { get; set; }
+
+            public OverriddenException(string message) : base(message)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
Some of the exceptions may contain several properties with the same name, which caused an error when add the item with the same key to the dictionary. This resulted on server response of `error:ok` with the `200` status code.

This occurs when a child exception overrides a property using the `new` keyword.
For example: https://github.com/npgsql/npgsql/blob/main/src/Npgsql/NpgsqlException.cs#L49